### PR TITLE
Fixed #54: Error when pressing 'down' on last item

### DIFF
--- a/neat.js
+++ b/neat.js
@@ -920,11 +920,12 @@ function init() {
 						nextLi.querySelector('a, span').focus();
 					} else {
 						do {
+							// Go up in hierarchy
 							li = li.parentNode.parentNode;
-							if (li) nextLi = li.nextElementSibling;
-							if (nextLi) LastLi = nextLi.querySelector('a, span');
-							if (LastLi) LastLi.focus(); // down on the last item in tree
-						} while (li && !nextLi);
+							// Go to next
+							if (li.tagName === 'LI') nextLi = li.nextElementSibling;
+							if (nextLi) nextLi.querySelector('a, span').focus();
+						} while (li.tagName === 'LI' && !nextLi);
 					}
 				}
 				break;


### PR DESCRIPTION
I added a check if the `li` element is effectively is a `li`. 
Also removed `LastLi`, it wasn't even a `li` element and the if(LastLi) was superfluous.
