### PR TITLE
Show more Omnibox search results

### DIFF
--- a/background.js
+++ b/background.js
@@ -83,7 +83,7 @@ if (chrome.omnibox){
 					if (!aTestTitle && bTestTitle) return 1;
 					return b.dateAdded - a.dateAdded;
 				});
-				results = results.slice(0, 6);
+				results = results.slice(0, 12);
 			}
 			var resultsLen = results.length;
 			firstResult = results.shift();


### PR DESCRIPTION
Omnibox search now shows more results (12 instead of 6), to handle the case were the user changed the flag (chrome://flags/#omnibox-ui-max-autocomplete-matches)
